### PR TITLE
fixes long line NOTE

### DIFF
--- a/man/get_year.Rd
+++ b/man/get_year.Rd
@@ -29,11 +29,16 @@ get_year(year_url, data.path = file.path("NSCH_data", "00_original_Stata"))
 }
 \examples{
 
-files2024 <- system.file(package="nsch", "extdata", c("datasets.2024.html", "nsch_2024_topical_Stata.zip"), mustWork=TRUE)
+files2024 <- system.file(
+  package="nsch", "extdata",
+  c("datasets.2024.html", "nsch_2024_topical_Stata.zip"),
+  mustWork=TRUE)
 dir2024 <- tempfile()
 dir.create(dir2024)
 file.copy(files2024, dir2024)
-nsch::get_year("https://www.census.gov/programs-surveys/nsch/data/datasets.2024.html", dir2024)
+nsch::get_year(
+  "https://www.census.gov/programs-surveys/nsch/data/datasets.2024.html",
+  dir2024)
 dir(dir2024)
 
 }


### PR DESCRIPTION
currently check says
```
* checking Rd line widths ... NOTE
Rd file 'get_year.Rd':
  \examples lines wider than 100 characters:
     files2024 <- system.file(package="nsch", "extdata", c("datasets.2024.html", "nsch_2024_topical_Stata.zip"), mustWork=TRUE)

These lines will be truncated in the PDF manual.
```
this PR should fix that.