### PR TITLE
rm importFrom nc

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,4 @@
 importFrom(utils, unzip)
-importFrom(nc, capture_all_str)
 importFrom(data.table, data.table)
 importFrom(utils, download.file)
 export(get_nsch_index)


### PR DESCRIPTION
this importFrom line is not necessary, because we use the double colon sytax to call the function in the code, `nc::capture_all_str()`.

importFrom is only necessary if we wanted to remove the double colon syntax, `capture_all_str()`. (which I do not recommend, in order to make it easy to see where the functions come from in the code)

@NAU-ASD3/r-reviewers please review?