### PR TITLE
Config: Add 2024 support, family_r collapse, k5q11 semantic fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.3.12
+Version: 2026.3.31
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.5.20
+Version: 2026.5.21
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.5.14
+Version: 2026.5.20
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nsch news and updates
 
+## 2026.3.31 (PR#35)
+
+* Config: added 2024 to `family_r` rename/transform, `sleep` merge, `hoursleep`/`hoursleep05`/`hospitaler`/`gowhensick` transforms, and `gowhensick` rename. Fixed `k5q11` 998→5 remap to preserve semantic distinction from 2024's native value 4.
+
 ## 2026.3.12 (PR#XX)
 
 * `impute_a1_grade_2016()` redistributes coarse 2016 a1_grade imputation across fine 9-category levels using proportions from non-2016 data, and updates higrade and higrade_tvis to match.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nsch news and updates
 
+## 2026.5.20 (PR#36)
+
+- Config: added 2024 to `family_r` rename/transform, `sleep` merge, `hoursleep`/`hoursleep05`/`hospitaler`/`gowhensick` transforms, `family_r` value collapse, and `gowhensick` rename. Fixed `k5q11` 998→5 remap to avoid colliding with native value 4 ("It was not possible to get a referral") that has existed since 2018.
+
 ## 2026.5.14 (PR#43)
 
 - Fixed `read_dta()` silently dropping the data.table over-allocation (truelength) by using base R `[[<-` assignment to coerce the `year` column to integer.  The lost over-allocation caused downstream `set()` calls in `transform_values()` to hit a function-boundary reallocation issue: new `_label` companion columns were visible inside the function but not to the caller, so `apply_do_labels()` received a data.table without them.  This produced `NA` for every config entry with a value remap and `new_label` (k4q20r, dentistvisit, bestforchild, discussopt, k5q11, k5q20_r, k5q21, k5q31_r, k5q40, k5q41, k5q42, k5q43, k5q44).  Replaced `[[<-` with `data.table::set()` which preserves truelength.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # nsch news and updates
 
-## 2026.5.20 (PR#36)
+## 2026.5.21 (PR#36)
 
-- Config: added 2024 to `family_r` rename/transform, `sleep` merge, `hoursleep`/`hoursleep05`/`hospitaler`/`gowhensick` transforms, `family_r` value collapse, and `gowhensick` rename. Fixed `k5q11` 998→5 remap to avoid colliding with native value 4 ("It was not possible to get a referral") that has existed since 2018.
+- Config: added 2024 to `family_r` rename/transform, `sleep` merge, `hoursleep`/`hoursleep05`/`hospitaler`/`gowhensick` transforms, `family_r` value collapse, and `gowhensick` rename.
+- Config: extended 998-remap transforms (`k4q20r`, `dentistvisit`, `bestforchild`, `discussopt`, `k5q11`, `k5q20_r`, `k5q21`, `k5q31_r`, `k5q40`, `k5q41`, `k5q42`, `k5q43`, `k5q44`) to include 2024 — these were previously scoped to 2016-2023, causing 2024 logical-skip respondents to incorrectly fall through to NA in the harmonized output instead of receiving their override factor level.
+- Fixed `k5q11` 998→5 remap to avoid colliding with native value 4 ("It was not possible to get a referral") that has existed since 2018.
 
 ## 2026.5.14 (PR#43)
 

--- a/inst/extdata/variable-config.json
+++ b/inst/extdata/variable-config.json
@@ -81,7 +81,7 @@
 				"new_label": ["Metropolitan Statistical Area", "Not Metropolitan Statistical Area"]
 			},
 			"hospitaler": {
-				"years": ["2016", "2017", "2022", "2023"],
+				"years": ["2016", "2017", "2022", "2023", "2024"],
 				"value": ["1", "2", "3", "4"],
 				"new_value": ["1", "2", "3", "3"],
 				"new_label": ["None", "1 time", "2 or more times", "2 or more times"]
@@ -93,7 +93,7 @@
 				"new_label": ["Clinic within a drug store or grocery store", "Some other place", "No usual place"]
 			},
 			"gowhensick": {
-				"years": ["2023"],
+				"years": ["2023", "2024"],
 				"value": ["4", "8", "998"],
 				"new_value": ["4", "7", "8"],
 				"new_label": ["Clinic or Health Center", "Some other place", "No usual place"]
@@ -143,7 +143,7 @@
 			"k5q11": {
 				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
 				"value": ["1", "2", "3", "998"],
-				"new_value": ["1", "2", "3", "4"],
+				"new_value": ["1", "2", "3", "5"],
 				"new_label": ["Not difficult", "Somewhat difficult", "Very difficult", "Did not need a referral"]
 			},
 			"k5q20_r": {
@@ -277,7 +277,7 @@
 				"new_name": "family"
 			},
 			"gowhensick": {
-				"years": ["2023"],
+				"years": ["2023",  "2024"],
 				"new_name": "k4q02_r"
 			}
 		},

--- a/inst/extdata/variable-config.json
+++ b/inst/extdata/variable-config.json
@@ -213,13 +213,13 @@
 				"new_label": ["Less than 1 hour per week", "This child does not need health care provided at home on a weekly basis"]
 			},
 			"hoursleep": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["1", "2", "3", "4", "5", "6", "7"],
 				"new_value": ["1", "1", "2", "3", "4", "5", "6"],
 				"new_label": ["Less than 7 hours", "Less than 7 hours", "7 hours", "8 hours", "9 hours", "10 hours", "11 or more hours"]
 			},
 			"hoursleep05": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["6", "7"],
 				"new_value": ["6", "6"],
 				"new_label": ["11 or more hours", "11 or more hours"]
@@ -241,6 +241,12 @@
 				"value": ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
 				"new_value": ["1", "2", "3", "4", "5", "5", "8", "8", "8"],
 				"new_label": ["Two biogical/adoptive parents, currently married", "Two biogical/adoptive parents, not currently married", "Two parents (at least one not biological/adoptive), currently married", "Two parents (at least one not biological/adoptive), not currently married", "Single mother", "Single mother", "Other relation", "Other relation", "Other relation"]
+			},
+			"family_r": {
+				"years": ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
+				"value": ["6", "7"],
+				"new_value": ["8", "8"],
+				"new_label": ["Other relation", "Other relation"]
 			},
 			"hcability": {
 				"years": ["2016", "2017", "2018"],
@@ -267,7 +273,7 @@
 				"new_name": "eyedoctor"
 			},
 			"family_r": {
-				"years": ["2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"new_name": "family"
 			},
 			"gowhensick": {
@@ -278,7 +284,7 @@
 
 		"merge_columns": {
 			"sleep": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"column_preferred": "hoursleep",
 				"column_fallback": "hoursleep05"
 			}

--- a/inst/extdata/variable-config.json
+++ b/inst/extdata/variable-config.json
@@ -117,79 +117,79 @@
 				"new_label": ["1st generation household [Child is born outside the United States and all reported parents are born outside the United States. At least one parent must be reported as born outside the United States.]", "2nd generation household [Child is born in the United States and at least one parent is born outside the United States OR child is born outside the United States, one parent is born in the United States and one parent is born outside the United States.]", "3rd+ generation [All parents in the household are born in the United States]", "Other [Child is born in the United States, parents are not listed.]"]
 			},
 			"k4q20r": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["1"],
 				"new_label": ["0 visits"]
 			},
 			"dentistvisit": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["1"],
 				"new_label": ["No preventive visits in past 12 months"]
 			},
 			"bestforchild": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"discussopt": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"k5q11": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["1", "2", "3", "998"],
 				"new_value": ["1", "2", "3", "5"],
 				"new_label": ["Not difficult", "Somewhat difficult", "Very difficult", "Did not need a referral"]
 			},
 			"k5q20_r": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["3"],
 				"new_label": ["Did not see more than one health care provider in the past 12 months"]
 			},
 			"k5q21": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["2"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"k5q31_r": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["3"],
 				"new_label": ["Did not need health care provider to communicate with these providers"]
 			},
 			"k5q40": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"k5q41": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"k5q42": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"k5q43": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]
 			},
 			"k5q44": {
-				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"],
+				"years": ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
 				"value": ["998"],
 				"new_value": ["4"],
 				"new_label": ["No healthcare provider visits last 12 months"]


### PR DESCRIPTION
Updates `variable-config.json` to support 2024 data and fix cross-year consistency issues.

## Changes

- **`family_r` transform (NEW)** — collapses "Single father" (6) and "Grandparent household" (7) to "Other relation" (8) for 2017–2024. Matches the original pipeline's post-combine `fct_recode()`.
- **`family_r` rename** — added "2024".
- **`sleep` merge** — added "2024".
- **`hoursleep` transform** — added "2024".
- **`hoursleep05` transform** — added "2024".
- **`hospitaler` transform** — added "2024" (same 4→3 category collapse).
- **`gowhensick` transform** — added "2024". The transform applies the same 8→7 remap that `k4q02_r` does for 2016–2022, harmonizing "Urgent Care Center" (which has appeared natively in the data since 2021) with "Some other place" across all years.
- **`gowhensick` rename** — added "2024".
- **`k5q11` 998→5 fix** — changed `998→4` to `998→5` for years 2016–2023. Native value 4 has existed since 2018 with the meaning "It was not possible to get a referral", so the prior `998→4` mapping was silently conflating logical-skip respondents with respondents who couldn't get a referral. Changing to 998→5 preserves both meanings as distinct factor levels.
- **998-remap transforms extended to 2024** — added "2024" to the years list for `k4q20r`, `dentistvisit`, `bestforchild`, `discussopt`, `k5q11`, `k5q20_r`, `k5q21`, `k5q31_r`, `k5q40`, `k5q41`, `k5q42`, `k5q43`, `k5q44`. These transforms remap value 998 (logical skip) to a non-sentinel `new_value` paired with a descriptive `new_label`. Without 2024 in the years list, 2024 logical-skip respondents fell through to NA in the harmonized output via `apply_do_labels`'s sentinel-code handling, dropping ~40,000 respondents per variable from analysis.

## Audit basis

Each year-list change was validated against the CAHMI [2016–2024 NSCH Variable Crosswalk](https://www.childhealthdata.org/learn-about-the-nsch/topics-questions-and-composite-measures). For every 998-remap variable, the crosswalk confirms the response option set in 2024 matches 2018–2023.

## Heatmap evidence (response to @tdhock review)

Pre-normalization heatmap: see comment above with full k5q11 distribution by year. Key findings:

- **k5q11 value 4** has existed since 2018 (not 2024 as previously framed). 2024's distribution is consistent with 2018–2023; this is not a 2024 semantic shift — it is a long-standing latent bug in the prior config that this PR fixes.
- **gowhensick/k4q02_r value 8 ("Urgent Care Center")** has existed since 2021 (not 2024). The existing `k4q02_r` transform already handles 8→7 for 2016–2022; this PR extends the same harmonization to 2023–2024 via the `gowhensick` transform.

Post-normalization heatmap will be posted as a follow-up comment with the corrected 2016–2024 factor-level distribution.

## Verified — no changes needed

- **k2q41a/diabetes**: 2024 uses `diabetes` natively
- **k4q31_r/eyedoctor**: 2024 uses `eyedoctor` natively (worth verifying — flagged in audit, separate follow-up)
- All `desired_variables` exist in 2024 either directly or via rename/merge

Updated framing on issue #35 to reflect the corrected timeline.