### PR TITLE
Add examples to all man pages, fix nsch:: prefix, clarify sentinel codes (closes #32, addresses #17)

### DIFF
--- a/man/apply_do_labels.Rd
+++ b/man/apply_do_labels.Rd
@@ -45,7 +45,7 @@ apply_do_labels(dt, define.dt)
     desc = c("Male", "Female", "No valid response",
              "Not in universe", "Suppressed for confidentiality")
   )
-  apply_do_labels(dt, define.dt)
+  nsch::apply_do_labels(dt, define.dt)
   dt$sc_sex
 }
 

--- a/man/get_years_csv.Rd
+++ b/man/get_years_csv.Rd
@@ -5,7 +5,7 @@
 }
 \description{
   First runs \code{\link{get_nsch_index}} to obtain a list of currently
-  available years of NSCH data. Then on eack year, we run
+  available years of NSCH data. Then on each year, we run
   \code{\link{get_year}} to 
   download the data to the \code{"00_original_Stata"} sub-directory of
   \code{data_dir}, and
@@ -33,4 +33,10 @@ get_years_csv(NSCH_data.path = "NSCH_data", verbose = FALSE)
 }
 \author{
 Toby Dylan Hocking
+}
+\examples{
+\dontrun{
+## Downloads all available years and converts to CSV.
+nsch::get_years_csv()
+}
 }

--- a/man/get_years_csv.Rd
+++ b/man/get_years_csv.Rd
@@ -37,6 +37,6 @@ Toby Dylan Hocking
 \examples{
 \dontrun{
 ## Downloads all available years and converts to CSV.
-nsch::get_years_csv()
+nsch::get_years_csv("NSCH_data", verbose=TRUE)
 }
 }

--- a/man/harmonize_year.Rd
+++ b/man/harmonize_year.Rd
@@ -48,3 +48,20 @@ harmonize_year(dt, config, year, define.dt)
 \author{
   Chris Reger
 }
+\examples{
+library(data.table)
+## Synthetic data: 2 rows, year 2099, one categorical variable.
+dt <- data.table(year = 2099L, sc_sex = c(1, 2))
+config <- list(
+  desired_variables = c("sc_sex"),
+  transformations = list(
+    transform = list(),
+    rename_columns = list(),
+    merge_columns = list()))
+define.dt <- data.table(
+  variable = c("sc_sex", "sc_sex"),
+  value = c("1", "2"),
+  desc = c("Male", "Female"))
+result <- nsch::harmonize_year(dt, config, 2099L, define.dt)
+result
+}

--- a/man/impute_a1_grade_2016.Rd
+++ b/man/impute_a1_grade_2016.Rd
@@ -54,3 +54,11 @@ impute_a1_grade_2016(combined.dt, dta.2016.path, seed = 1L)
 \author{
   Chris Reger
 }
+\examples{
+\dontrun{
+## Requires combined multi-year data and the raw 2016 .dta file.
+## Run after get_clean_data(impute.2016 = FALSE):
+dta.2016.path <- "NSCH_data/00_original_Stata/nsch_2016_topical.dta"
+nsch::impute_a1_grade_2016(clean.dt, dta.2016.path, seed = 1L)
+}
+}

--- a/man/merge_vars.Rd
+++ b/man/merge_vars.Rd
@@ -47,7 +47,7 @@ merge_vars(dt, merges, year)
     years = "2016",
     column_preferred = "col_a",
     column_fallback = "col_b"))
-  merge_vars(dt, merges, 2016L)
+  nsch::merge_vars(dt, merges, 2016L)
   dt
 
 }

--- a/man/na_tag_map.Rd
+++ b/man/na_tag_map.Rd
@@ -15,6 +15,12 @@
     \code{.l} \tab 998 \tab Logical skip \cr
     \code{.d} \tab 999 \tab Suppressed for confidentiality
   }
+  
+  These sentinel codes are a convention introduced by this package
+  (originally by the predecessor script \code{data-cleanup.R}) and do
+  not appear in the NSCH data or Stata files.  The highest real
+  response code across all NSCH variables is 400, so values above 900
+  are safe to use as sentinels.
 
   \code{\link{read_dta}} replaces tagged NAs with these codes at
   ingestion time so the four missingness types survive as distinct

--- a/man/rename_vars.Rd
+++ b/man/rename_vars.Rd
@@ -42,7 +42,7 @@ rename_vars(dt, renames, year)
   dt <- data.table::data.table(old_var = c(1, 2))
   renames <- list(old_var = list(
     years = "2016", new_name = "new_var"))
-  rename_vars(dt, renames, 2016L)
+  nsch::rename_vars(dt, renames, 2016L)
 names(dt)
 
 }

--- a/man/subset_vars.Rd
+++ b/man/subset_vars.Rd
@@ -35,7 +35,7 @@ subset_vars(dt, desired.variables)
   dt <- data.table::data.table(
     a = 1:3, a_label = c("x", "y", "z"),
     b = 4:6, c = 7:9)
-  result <- subset_vars(dt, c("a", "c"))
+  result <- nsch::subset_vars(dt, c("a", "c"))
 names(result)
 
 }

--- a/man/transform_values.Rd
+++ b/man/transform_values.Rd
@@ -47,7 +47,7 @@ transform_values(dt, transforms, year)
     value = c("1", "2"),
     new_value = c("1", "2"),
     new_label = c("Male", "Female")))
-  transform_values(dt, transforms, 2016L)
+  nsch::transform_values(dt, transforms, 2016L)
 dt
 
 }


### PR DESCRIPTION
Addresses issue #32  — every `.Rd` man page now has an `\examples{}` section, and all examples use the `nsch::` prefix established in PR #30.

Also clarifies in `na_tag_map.Rd` that the 996-999 sentinel codes are a package convention, not NSCH data values (addresses #17).

### New examples added
- **`harmonize_year.Rd`** — runnable example with synthetic data and minimal config
- **`impute_a1_grade_2016.Rd`** — `\dontrun{}` example (requires real NSCH data)
- **`get_years_csv.Rd`** — `\dontrun{}` example (downloads data)

### `nsch::` prefix added to existing examples
- `apply_do_labels.Rd`
- `transform_values.Rd`
- `rename_vars.Rd`
- `merge_vars.Rd`
- `subset_vars.Rd`

### Other fix
- Fixed typo in `get_years_csv.Rd` description: "eack" → "each"