### PR TITLE
Fix: harmonize_year silently dropping _label companion columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.4.27
+Version: 2026.5.14
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # nsch news and updates
 
-## 2026.5.14 (PR#XX)
+## 2026.5.14 (PR#41)
 
 - Fixed `harmonize_year()` silently dropping the `_label` companion columns added by `transform_values()`.  The function now captures return values from each pipeline step, which is necessary because `data.table::set()` calls that introduce new columns can fall back to copy-on-allocate.  Previously, every variable with a `998 →` remap in the config (k4q20r, dentistvisit, bestforchild, discussopt, k5q11, k5q20_r, k5q21, k5q31_r, k5q40, k5q41, k5q42, k5q43, k5q44) produced `NA` in the harmonized output for the remapped rows instead of receiving the intended override label.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nsch news and updates
 
+## 2026.5.14 (PR#XX)
+
+- Fixed `harmonize_year()` silently dropping the `_label` companion columns added by `transform_values()`.  The function now captures return values from each pipeline step, which is necessary because `data.table::set()` calls that introduce new columns can fall back to copy-on-allocate.  Previously, every variable with a `998 →` remap in the config (k4q20r, dentistvisit, bestforchild, discussopt, k5q11, k5q20_r, k5q21, k5q31_r, k5q40, k5q41, k5q42, k5q43, k5q44) produced `NA` in the harmonized output for the remapped rows instead of receiving the intended override label.
+
 ## 2026.4.27 (PR#34)
 
 - `get_all_years()` discovers NSCH .dta and .do files in a data directory, returning a data.table mapping each year to its file paths.

--- a/R/harmonize_year.R
+++ b/R/harmonize_year.R
@@ -1,8 +1,13 @@
 harmonize_year <- function(dt, config, year, define.dt) {
-  transform_values(dt, config$transformations$transform, year)
-  rename_vars(dt, config$transformations$rename_columns, year)
-  merge_vars(dt, config$transformations$merge_columns, year)
+  ## Capture return values from all pipeline steps. Most modify `dt` by
+  ## reference, but `set()` calls that introduce new columns can fall back
+  ## to copy-on-allocate if the data.table lacks truelength headroom — in
+  ## which case the new column appears only on the returned object.
+  ## `subset_vars()` always returns a new data.table.
+  dt <- transform_values(dt, config$transformations$transform, year)
+  dt <- rename_vars(dt, config$transformations$rename_columns, year)
+  dt <- merge_vars(dt, config$transformations$merge_columns, year)
   dt <- subset_vars(dt, config$desired_variables)
-  apply_do_labels(dt, define.dt)
+  dt <- apply_do_labels(dt, define.dt)
   dt
 }

--- a/tests/testthat/test-harmonize_year.R
+++ b/tests/testthat/test-harmonize_year.R
@@ -36,12 +36,14 @@ test_that("produces same result as calling steps manually", {
     value = c("1", "2"),
     desc = c("Male", "Female")
   )
-  ## Manual pipeline on dt1.
-  nsch::transform_values(dt1, config$transformations$transform, 2099L)
-  nsch::rename_vars(dt1, config$transformations$rename_columns, 2099L)
-  nsch::merge_vars(dt1, config$transformations$merge_columns, 2099L)
+  ## Manual pipeline on dt1.  Capture return values from each step to
+  ## ensure new columns added via data.table::set() are preserved even
+  ## when truelength is exhausted.
+  dt1 <- nsch::transform_values(dt1, config$transformations$transform, 2099L)
+  dt1 <- nsch::rename_vars(dt1, config$transformations$rename_columns, 2099L)
+  dt1 <- nsch::merge_vars(dt1, config$transformations$merge_columns, 2099L)
   dt1 <- nsch::subset_vars(dt1, config$desired_variables)
-  nsch::apply_do_labels(dt1, define.dt)
+  dt1 <- nsch::apply_do_labels(dt1, define.dt)
   ## harmonize_year on dt2.
   result <- nsch::harmonize_year(dt2, config, 2099L, define.dt)
   expect_identical(result, dt1)
@@ -67,4 +69,45 @@ test_that("works with empty transform rules", {
   )
   result <- nsch::harmonize_year(dt, config, 2099L, define.dt)
   expect_identical(result[["sc_sex"]], factor(c("Male", "Female"), c("Male", "Female")))
+})
+
+test_that("preserves _label override through full pipeline (regression for return-capture bug)", {
+  ## This test guards against a bug where transform_values() adds a
+  ## `_label` companion column via data.table::set(), but the new
+  ## column is silently dropped if harmonize_year() does not capture
+  ## the return value.  The bug manifests as the remapped rows
+  ## becoming NA in the final factor instead of receiving the
+  ## override label from `new_label`.
+  dt <- data.table(
+    year = 2099L,
+    test_var = c(1, 2, 998, 998, 998)
+  )
+  config <- list(
+    desired_variables = "test_var",
+    transformations = list(
+      transform = list(
+        test_var = list(
+          years = "2099",
+          value = c("998"),
+          new_value = c("5"),
+          new_label = c("Override label")
+        )
+      ),
+      rename_columns = list(),
+      merge_columns = list()
+    )
+  )
+  define.dt <- data.table(
+    variable = c("test_var", "test_var"),
+    value = c("1", "2"),
+    desc = c("One", "Two")
+  )
+  result <- nsch::harmonize_year(dt, config, 2099L, define.dt)
+  ## The override label must appear as a real factor level, not NA.
+  expect_in("Override label", levels(result[["test_var"]]))
+  ## Three rows of value 998 should have been remapped to "Override label".
+  expect_identical(
+    as.character(result[["test_var"]]),
+    c("One", "Two", "Override label", "Override label", "Override label")
+  )
 })


### PR DESCRIPTION
## Summary

`harmonize_year()` was silently dropping the `_label` companion columns added by `transform_values()`, causing every variable with a `998 → new_value` config remap to produce `NA` in the harmonized output instead of receiving the intended override label.

@tdhock — flagging this for review since it affects pipeline correctness broadly.

## Root cause

`transform_values()` adds `_label` companion columns via `data.table::set()`. When `set()` introduces a new column, it can fall back to copy-on-allocate if the data.table lacks truelength headroom — in which case the new column appears only on the returned object, not on the original reference.

`harmonize_year()` did not capture return values from its pipeline steps, so the `_label` columns were lost between `transform_values()` and `apply_do_labels()`.

Discovered while generating the post-normalization heatmap @tdhock requested on #36. The harmonized 2016 `k5q11` showed 41,071 NA values instead of 40,818 rows labeled "Did not need a referral" (matching the original 998 count exactly).

## Impact

Every config entry with a value remap and `new_label` was affected. In the current config that's:

- `k4q20r`, `dentistvisit`, `bestforchild`, `discussopt`
- `k5q11`, `k5q20_r`, `k5q21`, `k5q31_r`
- `k5q40`, `k5q41`, `k5q42`, `k5q43`, `k5q44`

All produced `NA` for the remapped rows in the harmonized output instead of the intended override factor level.

## Fix

Capture return values from each pipeline step in `harmonize_year()`:

```r
dt <- transform_values(dt, config$transformations$transform, year)
dt <- rename_vars(dt, config$transformations$rename_columns, year)
dt <- merge_vars(dt, config$transformations$merge_columns, year)
dt <- subset_vars(dt, config$desired_variables)
dt <- apply_do_labels(dt, define.dt)
```

Most of these modify by reference, but capturing returns is the safe pattern when any function might reallocate. A comment in the source explains why.

## Why this wasn't caught earlier

The existing `test-harmonize_year.R` "produces same result as calling steps manually" test compared `harmonize_year()` output against a manual pipeline — but the manual pipeline used the same buggy pattern (not capturing returns). Both were wrong in the same way, so the assertion passed.

## Changes

- `R/harmonize_year.R` — capture return values; comment explaining why
- `tests/testthat/test-harmonize_year.R` — update existing manual pipeline to capture returns; add a regression test that exercises a 998-remap end-to-end and asserts the override label appears as a real factor level
- `DESCRIPTION` — version bump to 2026.5.14
- `NEWS.md` — entry describing the fix and affected variables

## Verification

- All 228 existing tests pass
- New regression test passes and would fail against the prior `harmonize_year()` implementation
- `R CMD check` Status: OK
- Manually verified against 2016 and 2017 NSCH data: 998-rows now correctly receive their override label