### PR TITLE
Fix: read_dta dropping data.table truelength via base R [[<- assignment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.4.27
+Version: 2026.5.14
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,6 @@
 importFrom(utils, unzip)
 importFrom(data.table, data.table)
+importFrom(data.table, ":=")
 importFrom(utils, download.file)
 export(get_nsch_index)
 export(get_year)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nsch news and updates
 
+## 2026.5.14 (PR#XX)
+
+- Fixed `read_dta()` silently dropping the data.table over-allocation (truelength) by using base R `[[<-` assignment to coerce the `year` column to integer.  The lost over-allocation caused downstream `set()` calls in `transform_values()` to hit a function-boundary reallocation issue: new `_label` companion columns were visible inside the function but not to the caller, so `apply_do_labels()` received a data.table without them.  This produced `NA` for every config entry with a value remap and `new_label` (k4q20r, dentistvisit, bestforchild, discussopt, k5q11, k5q20_r, k5q21, k5q31_r, k5q40, k5q41, k5q42, k5q43, k5q44).  Replaced `[[<-` with `data.table::set()` which preserves truelength.
+
 ## 2026.4.27 (PR#34)
 
 - `get_all_years()` discovers NSCH .dta and .do files in a data directory, returning a data.table mapping each year to its file paths.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # nsch news and updates
 
-## 2026.5.14 (PR#XX)
+## 2026.5.14 (PR#43)
 
 - Fixed `read_dta()` silently dropping the data.table over-allocation (truelength) by using base R `[[<-` assignment to coerce the `year` column to integer.  The lost over-allocation caused downstream `set()` calls in `transform_values()` to hit a function-boundary reallocation issue: new `_label` companion columns were visible inside the function but not to the caller, so `apply_do_labels()` received a data.table without them.  This produced `NA` for every config entry with a value remap and `new_label` (k4q20r, dentistvisit, bestforchild, discussopt, k5q11, k5q20_r, k5q21, k5q31_r, k5q40, k5q41, k5q42, k5q43, k5q44).  Replaced `[[<-` with `data.table::set()` which preserves truelength.
 

--- a/R/read_dta.R
+++ b/R/read_dta.R
@@ -1,4 +1,5 @@
 read_dta <- function(dta.path){
+  year <- NULL  # for R CMD check
   if(!file.exists(dta.path)){
     stop(
       "dta.path should be the path to a Stata .dta file, ",
@@ -34,6 +35,5 @@ read_dta <- function(dta.path){
   if(!("year" %in% names(dt))){
     stop("dta file does not contain a 'year' column: ", dta.path)
   }
-  data.table::set(dt, j = "year", value = as.integer(dt[["year"]]))
-  dt
+  dt[, year := as.integer(year)][]
 }

--- a/R/read_dta.R
+++ b/R/read_dta.R
@@ -34,6 +34,6 @@ read_dta <- function(dta.path){
   if(!("year" %in% names(dt))){
     stop("dta file does not contain a 'year' column: ", dta.path)
   }
-  dt[["year"]] <- as.integer(dt[["year"]])
+  data.table::set(dt, j = "year", value = as.integer(dt[["year"]]))
   dt
 }

--- a/tests/testthat/test-read_dta.R
+++ b/tests/testthat/test-read_dta.R
@@ -65,3 +65,16 @@ test_that("informative error for missing dta file", {
     does.not.exist
   ), fixed = TRUE)
 })
+
+test_that("read_dta preserves data.table over-allocation (regression for #41)", {
+  ## Bug: base R [[<- assignment was used to coerce the year column to
+  ## integer, which silently dropped data.table's over-allocation.
+  ## Downstream functions calling data.table::set() to add new columns
+  ## then hit reallocation at a function-call boundary, causing the new
+  ## columns to be lost from the caller's view.
+  tf <- tempfile(fileext = ".dta")
+  test_df <- data.frame(year = 2099L, x = c(1, 2, 3))
+  haven::write_dta(test_df, tf)
+  dt <- nsch::read_dta(tf)
+  expect_gt(data.table::truelength(dt), length(dt))
+})


### PR DESCRIPTION
## Summary

`nsch::read_dta()` was silently dropping the data.table over-allocation (`truelength`) when coercing the `year` column to integer, by using base R's `[[<-` replacement. This caused every downstream variable with a `998 → new_value + new_label` config remap to produce `NA` in the harmonized output instead of receiving the intended override label.

Replaces #41 — same bug, correct root cause this time. The diagnostic journey is in that PR's comments for the record.

## Root cause

The last functional line of `read_dta()` was:

```r
dt[["year"]] <- as.integer(dt[["year"]])
```

This is base R's `[[<-` assignment, which copies the underlying list and drops data.table's `truelength` attribute. The output of `read_dta` therefore reported `truelength = 0` despite the prior `data.table(raw)` call producing proper over-allocation (`truelength = 1460`).

A bisect through `read_dta` confirms this is the single line responsible:

```
Step 4 — data.table(raw)
  truelength: 1460
Step 5 — dt[["year"]] <- as.integer(dt[["year"]])
  truelength: 0
```

Downstream, `transform_values()` calls `data.table::set()` to add `_label` companion columns. With `truelength = 0`, every `set()` of a new column requires reallocation. Across the function-call boundary in `harmonize_year()`, the reallocated data.table is only bound in the function's local frame — the caller's binding still points to the original truelength-0 object without the new columns. `apply_do_labels()` then receives a data.table without the `_label` companions and produces `NA` for every remapped row.

## Impact

Every config entry with a value remap and `new_label` was affected:

- `k4q20r`, `dentistvisit`, `bestforchild`, `discussopt`
- `k5q11`, `k5q20_r`, `k5q21`, `k5q31_r`
- `k5q40`, `k5q41`, `k5q42`, `k5q43`, `k5q44`

All produced `NA` for the remapped rows in the harmonized output instead of the intended override factor level.

## Fix

Replace the base R `[[<-` with `data.table::set()`, which preserves over-allocation:

```r
data.table::set(dt, j = "year", value = as.integer(dt[["year"]]))
```

One-line change. `harmonize_year()` is untouched — its original implementation (which doesn't capture return values from its pipeline steps) works correctly once `read_dta` no longer destroys the truelength.

## Verification

- **Unit test added** to `test-read_dta.R` asserting `truelength(dt) > length(dt)` after `read_dta`. Verified the test fails with the bug present and passes with the fix.
- **All 227 existing tests pass.**
- **End-to-end check**: re-ran `harmonize_year(2017)` against real NSCH data. With the fix, 998-remapped k5q11 rows correctly receive their "Did not need a referral" label (17,354 rows). Without the fix, those rows become `NA`.
- **`R CMD check` Status: OK.**

## Changes

- `R/read_dta.R` — replaced `[[<-` with `data.table::set()` (one line)
- `tests/testthat/test-read_dta.R` — added regression test asserting truelength is preserved
- `DESCRIPTION` — version bump to 2026.5.14
- `NEWS.md` — entry describing the fix and affected variables