### PR TITLE
Expand .gitignore to cover R build artifacts and editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,45 @@
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+.RDataTmp
+
+# User-specific files
+.Ruserdata
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build / check
+/*.tar.gz
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+*.Rproj
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+# R Environment Variables
+.Renviron
+
+# macOS
+.DS_Store
+
+# Editor backups
 *~
-.Rproj.user


### PR DESCRIPTION
Expands the minimal `.gitignore` (previously just `*~` and `.Rproj.user`) to the standard R-package set, organized into commented sections.

## Why

`R CMD build`/`check` generate `nsch.Rcheck/`, `*.tar.gz`, and `.Rhistory` at the repo root, none of which were ignored. A `git add -A` would stage all of them (~100 files from the `.Rcheck/` dir alone). This adds the usual `usethis`-style ignores so build output and session/editor files stay out of commits.

## Notes

- Build artifacts `/*.tar.gz` and `/*.Rcheck/` are root-anchored, so they only match where the build tools produce them — they won't ignore a tarball that's legitimately part of a subdirectory fixture.
- The two existing entries (`*~`, `.Rproj.user`) are preserved.
- **`*.Rproj` is included** — this ignores the RStudio project file. I went with ignoring it since it wasn't tracked anyway, though I know some teams prefer to commit `.Rproj` to share project settings. Let me know if you'd like me to drop that one line if you'd rather it be tracked.