### PR TITLE
Add .Rproj and .Rproj.user to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@ README.md
 .github
 .gitignore
 build.sh
+^.*\.Rproj$
+^\.Rproj\.user$


### PR DESCRIPTION
Companion to the `.gitignore` expansion in #56. That PR stopped `.Rproj` / `.Rproj.user/` from being committed; this adds the matching `.Rbuildignore` entries so they're also excluded from the package build:

- `^.*\.Rproj$`
- `^\.Rproj\.user$`

Without these, `R CMD build` would bundle the RStudio project file and user dir into the tarball, which produces an `R CMD check` NOTE about non-standard top-level files. Keeping `.gitignore` and `.Rbuildignore` in sync avoids that.

No package code or behavior change.