### PR TITLE
Drop k4q31_r→eyedoctor rename and remove eyedoctor from desired_variables (closes #47)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.6.2
+Version: 2026.6.4
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nsch news and updates
 
+## 2026.6.4 (PR#XX)
+
+- Config: dropped the `k4q31_r` → `eyedoctor` rename and removed `eyedoctor` from `desired_variables` (closes #47). The two underlying survey questions are distinct and shouldn't be conflated under one harmonized variable, so neither the renamed `eyedoctor` column nor the raw `k4q31_r` column is carried into the harmonized output.
+
 ## 2026.6.2 (PR#53)
  
 - Config: resolved the remaining safe label-drift cases from #50 (stacked on #51).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # nsch news and updates
 
-## 2026.6.4 (PR#XX)
+## 2026.6.4 (PR#59)
 
 - Config: dropped the `k4q31_r` → `eyedoctor` rename and removed `eyedoctor` from `desired_variables` (closes #47). The two underlying survey questions are distinct and shouldn't be conflated under one harmonized variable, so neither the renamed `eyedoctor` column nor the raw `k4q31_r` column is carried into the harmonized output.
 

--- a/inst/extdata/variable-config.json
+++ b/inst/extdata/variable-config.json
@@ -20,7 +20,7 @@
 		"birthwt", "k2q05",
 
 		"c4q04", "hospitaler", "k4q01", "k4q02_r", "k4q20r", "k4q22_r",
-		"k4q23", "k4q24_r", "k4q27", "dentistvisit", "eyedoctor", "k4q36",
+		"k4q23", "k4q24_r", "k4q27", "dentistvisit", "k4q36",
 		"k6q15", "s4q01", "usualgo", "wgtconc",
 
 		"bestforchild", "discussopt", "k4q04_r", "k5q10", "k5q11", "k5q20_r",
@@ -447,11 +447,6 @@
 			"k2q41a": {
 				"years":    ["2016", "2017", "2018", "2019", "2020", "2021"],
 				"new_name": "diabetes"
-			},
-
-			"k4q31_r": {
-				"years":    ["2016", "2017", "2018", "2019", "2020", "2021"],
-				"new_name": "eyedoctor"
 			}
 
 		},


### PR DESCRIPTION
Closes #47.

Per the 5/27 discussion, dropping both: the `k4q31_r` survey item and the later `eyedoctor` item are distinct questions that shouldn't be conflated under one harmonized variable.

## Changes

- Removed the `k4q31_r` → `eyedoctor` entry from `rename_columns`.
- Removed `eyedoctor` from `desired_variables`.

Net effect: neither the raw `k4q31_r` column nor a renamed `eyedoctor` column is carried into the harmonized output.

## Verification

- Whole-repo grep confirms `eyedoctor`/`k4q31_r` appeared only in the config — no man page, test, or `check_*` utility referenced them, so the change is self-contained.
- `R CMD check` Status: OK, all tests pass.
- Config diff is minimal (1 line in `desired_variables`, the rename block removed) — no reformatting.