### PR TITLE
Fix k2q01_d 2016 labels: supply full 1-6 scale via transform

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: nsch
 Type: Package
 Encoding: UTF-8
 Title: National Survey of Children’s Health
-Version: 2026.6.26
+Version: 2026.6.27
 Authors@R: c(
     person("Toby", "Hocking",
      email="toby.hocking@r-project.org",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # nsch news and updates
 
-## 2026.6.27 (PR#XX)
+## 2026.6.27 (PR#61)
 
 - Fixed `k2q01_d` (child's teeth condition) coming back unlabeled for 2016. The 2016 `.do` attaches `k2q01_d` to an incomplete label set that only defines value 6 ("no teeth"), with the `Excellent`-`Poor` scale (values 1-5) living in a separate label set that never got applied, so 2016 values 1-5 fell through to NA.
 - Expanded the `k2q01_d` transform to supply the full 1-6 labels. 2017-2024 are unaffected (their `.do` defines the scale directly, and `apply_do_labels()` runs after `transform_values()`), so the fix is self-limiting to 2016.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # nsch news and updates
 
+## 2026.6.27 (PR#XX)
+
+- Fixed `k2q01_d` (child's teeth condition) coming back unlabeled for 2016. The 2016 `.do` attaches `k2q01_d` to an incomplete label set that only defines value 6 ("no teeth"), with the `Excellent`-`Poor` scale (values 1-5) living in a separate label set that never got applied, so 2016 values 1-5 fell through to NA.
+- Expanded the `k2q01_d` transform to supply the full 1-6 labels. 2017-2024 are unaffected (their `.do` defines the scale directly, and `apply_do_labels()` runs after `transform_values()`), so the fix is self-limiting to 2016.
+
 ## 2026.6.26 (PR#45)
 
 - Fixed `apply_do_labels()` failing to label columns whose names changed via `rename_vars()` or `merge_vars()`. Affected columns came out as raw integer codes (instead of labeled factors) in years where the rename or merge applied.

--- a/inst/extdata/variable-config.json
+++ b/inst/extdata/variable-config.json
@@ -282,9 +282,9 @@
 
 			"k2q01_d": {
 				"years":     ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"],
-				"value":     ["6"],
-				"new_value": ["6"],
-				"new_label": ["This child does not have any teeth [T1 only]"]
+				"value":     ["1", "2", "3", "4", "5", "6"],
+				"new_value": ["1", "2", "3", "4", "5", "6"],
+				"new_label": ["Excellent", "Very Good", "Good", "Fair", "Poor", "This child does not have any teeth [T1 only]"]
 			},
 
 			"k2q35a_1_years": {

--- a/tests/testthat/test-transform_values.R
+++ b/tests/testthat/test-transform_values.R
@@ -66,3 +66,26 @@ test_that("missing variable in dt is silently skipped", {
   expect_no_error(nsch::transform_values(dt, transforms, 2016L))
   expect_identical(names(dt), "x")
 })
+test_that("identity remap supplies labels without changing values (k2q01_d #60)", {
+  ## Regression for #60: 2016 k2q01_d values 1-5 came out unlabeled because the
+  ## 2016 .do attached an incomplete label set. The config supplies identity
+  ## remaps (value == new_value) carrying the Excellent-Poor labels so the
+  ## scale is labeled even when the .do define omits it.
+  dt <- data.table::data.table(k2q01_d = c(1, 2, 3, 4, 5, 6))
+  transforms <- list(
+    k2q01_d = list(
+      years = c("2016", "2017", "2018", "2019", "2020",
+                "2021", "2022", "2023", "2024"),
+      value = c("1", "2", "3", "4", "5", "6"),
+      new_value = c("1", "2", "3", "4", "5", "6"),
+      new_label = c("Excellent", "Very Good", "Good", "Fair", "Poor",
+                    "This child does not have any teeth [T1 only]")))
+  nsch::transform_values(dt, transforms, 2016L)
+  ## Values unchanged (identity remap).
+  expect_identical(dt[["k2q01_d"]], c(1, 2, 3, 4, 5, 6))
+  ## Labels applied across the full scale.
+  expect_identical(
+    dt[["k2q01_d_label"]],
+    c("Excellent", "Very Good", "Good", "Fair", "Poor",
+      "This child does not have any teeth [T1 only]"))
+})


### PR DESCRIPTION
Closes #60.

## Root cause

`k2q01_d` (condition of child's teeth) came back unlabeled for 2016 — the entire Excellent-Poor scale dropped to NA, leaving only "This child does not have any teeth". Traced it to the 2016 `.do` file: it attaches `k2q01_d` to the label set `k2q01_d_lab`, which defines only value 6 ("no teeth"). The 1-5 Excellent-Poor scale is defined in a separate set (`k2q01_lab`) and never gets applied to `k2q01_d`. `parse_do()` extracts what the `.do` says, with the result that values 1-5 had no label and fell through as NA. 2017-2024 define the full scale directly under `k2q01_d`, so they were never affected.

Confirmed the scope: k2q01_d is the only `desired_variables` variable with this pattern (a categorical scale attached to an incomplete label set). The other low-label-count variables in 2016 (a1_age, a2_age, hhcount, famcount, k11q43r) are continuous response boxes, in which a single top-coded label is correct.

## Fix

Expanded the existing `k2q01_d` transform entry to supply "identity" remaps (value == new_value) carrying the full 1-6 labels. Because `transform_values()` runs before `apply_do_labels()` in `harmonize_year()`, the effect is self-limiting:

- 2016: the `.do` has no 1-5 labels to apply, so the transform's labels survive → scale is now labeled.
- 2017-2024: `apply_do_labels()` overwrites with the `.do`'s own (identical) labels → no change.

Verified label text matches the `.do` spelling across 2018/2020/2024 (Excellent / Very Good / Good / Fair / Poor).

## Verification

- 2016 k2q01_d now labels the full scale (Excellent 26,170, Very Good 14,735, Good 6,286, Fair 1,482, Poor 246, no-teeth 1,164); NA dropped from 49,048 to 129 (ordinary item-missingness, in line with other years).
- 2017-2024 counts are byte-identical to before the change.
- Added a regression test in `test-transform_values.R` asserting the 1-6 identity-remap-with-labels behavior.
- `R CMD check`: Status OK, all tests pass.

The issue was initially surfaced by the year-level audit (#46).